### PR TITLE
Get away from master/slave lingo

### DIFF
--- a/master.py
+++ b/master.py
@@ -8,7 +8,7 @@ import struct
 import yaml
 
 # start listening
-class master:
+class main:
     sock = None
     def __init__(self):
         pass
@@ -53,7 +53,7 @@ class master:
 
 
 if __name__ == "__main__":
-    master = master()
+    main = main()
     args = {'content':'sanfrancisco.jpg','style':'starry_night.jpg','model':'vgg16','ratio':1e4}
-    master.dispatch('10.0.0.64',8667,args)
-    # master.dispatch('127.0.0.1', 8666, args)
+    main.dispatch('10.0.0.64',8667,args)
+    # main.dispatch('127.0.0.1', 8666, args)

--- a/slave.py
+++ b/slave.py
@@ -13,18 +13,18 @@ import requests
 # logging
 LOG_FORMAT = "%(filename)s:%(funcName)s:%(asctime)s.%(msecs)03d -- %(message)s"
 
-class slave:
+class subordinate:
     conf = None
     sock = None
     host = None
     port =None
-    conn = None #保存和master的socket
+    conn = None #保存和main的socket
     #start listening
     def __init__(self,conf):
         self.conf =conf
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.host = conf.get("transmission", "slave_ip")
-        self.port = conf.getint("transmission", "slave_port")
+        self.host = conf.get("transmission", "subordinate_ip")
+        self.port = conf.getint("transmission", "subordinate_port")
 
     def start(self):
 
@@ -48,7 +48,7 @@ class slave:
             trans.process()
             # data = conn.recv(1024)
             # print data
-            # conn.send("slave receive your order. Your order is '%s'"%data)
+            # conn.send("subordinate receive your order. Your order is '%s'"%data)
 
     #json
     def receive_json(self):
@@ -97,5 +97,5 @@ if __name__=="__main__":
     conf = ConfigParser.ConfigParser()
     conf.read('./client.config')
     logging.basicConfig(format=LOG_FORMAT, datefmt="%H:%M:%S", level=logging.INFO)
-    slave =slave(conf)
-    slave.start()
+    subordinate =subordinate(conf)
+    subordinate.start()

--- a/web/transfer/handlers.py
+++ b/web/transfer/handlers.py
@@ -1,8 +1,8 @@
 #encoding=utf8
 from django.conf import settings
 from django.utils import timezone
-from .models import Task,Slave
-from .master import master
+from .models import Task,Subordinate
+from .main import main
 import uuid
 import os
 def handle_upload_file(request,content,style):
@@ -20,7 +20,7 @@ def handle_upload_file(request,content,style):
         destination.close()
     task = Task(content=content_storage,style=style_storage,user=request.user,sub_time=timezone.now())
     task.save()
-    m = master()
+    m = main()
     args = {'task_id':task.id,'content': content_storage, 'style': style_storage, 'model': 'vgg16', 'ratio': 1e4}
     # m.dispatch('10.0.0.64', 8667, args)
     print "New task:{0}".format(args)

--- a/web/transfer/master.py
+++ b/web/transfer/master.py
@@ -8,7 +8,7 @@ import struct
 import yaml
 
 # start listening
-class master:
+class main:
     sock = None
     def __init__(self):
         pass
@@ -53,7 +53,7 @@ class master:
 
 
 if __name__ == "__main__":
-    master = master()
+    main = main()
     args = {'task_id':2,'content':'sanfrancisco.jpg','style':'starry_night.jpg','model':'vgg16','ratio':1e4}
-    # master.dispatch('10.0.0.64',8667,args)
-    master.dispatch('127.0.0.1', 8666, args)
+    # main.dispatch('10.0.0.64',8667,args)
+    main.dispatch('127.0.0.1', 8666, args)

--- a/web/transfer/migrations/0001_initial.py
+++ b/web/transfer/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='Slave',
+            name='Subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('addr', models.CharField(max_length=200)),
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.AddField(
-            model_name='slave',
+            model_name='subordinate',
             name='task',
             field=models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='transfer.Task'),
         ),


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.